### PR TITLE
Update Developing.md to include prerequisites necessary for macos

### DIFF
--- a/Developing.md
+++ b/Developing.md
@@ -22,6 +22,17 @@ rustup target list --installed
 rustup target add wasm32-unknown-unknown
 ```
 
+### Using macos?
+
+You'll need to install LLVM using Homebrew:
+```sh
+brew install llvm
+echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.profile
+echo 'export CC=/usr/local/opt/llvm/bin/clang' >> ~/.profile
+echo 'export AR=/usr/local/opt/llvm/bin/llvm-ar' >> ~/.profile
+source ~/.profile
+```
+
 ## Compiling and running tests
 
 Now that you created your custom contract, make sure you can compile and run it before


### PR DESCRIPTION
The version of llvm included in a default macos install doesn't support WASM as a target. Therefore, the instructions as is don't work for someone trying to build on macos.

The solution is to use llvm from Homebrew, a common goto package manager for macos.