### PR TITLE
feat(snip-20): enable importing contract as library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "snip20-reference-impl"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "base64 0.12.3",
  "bincode2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "snip20-reference-impl"
-version = "0.1.0"
+version = "1.5.0"
 dependencies = [
  "base64 0.12.3",
  "bincode2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snip20-reference-impl"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Itzik <itzik@keytango.io>", "Tomasz Kopacki <tomasz@kopacki.net>"]
 edition = "2018"
 exclude = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snip20-reference-impl"
-version = "0.2.1"
+version = "1.5.0"
 authors = ["Itzik <itzik@keytango.io>", "Tomasz Kopacki <tomasz@kopacki.net>"]
 edition = "2018"
 exclude = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snip20-reference-impl"
-version = "0.1.0"
-authors = ["Itzik <itzik@keytango.io>"]
+version = "0.2.0"
+authors = ["Itzik <itzik@keytango.io>", "Tomasz Kopacki <tomasz@kopacki.net>"]
 edition = "2018"
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -29,6 +29,8 @@ overflow-checks = true
 # for more explicit tests, cargo test --features=backtraces
 #default = ["debug-print"]
 backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all init/handle/query exports
+library = []
 
 # debug-print = ["cosmwasm-std/debug-print"]
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snip20-reference-impl"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Itzik <itzik@keytango.io>", "Tomasz Kopacki <tomasz@kopacki.net>"]
 edition = "2018"
 exclude = [

--- a/schema/handle_answer.json
+++ b/schema/handle_answer.json
@@ -496,10 +496,10 @@
     {
       "type": "object",
       "required": [
-        "revoke_pemit"
+        "revoke_permit"
       ],
       "properties": {
-        "revoke_pemit": {
+        "revoke_permit": {
           "type": "object",
           "required": [
             "status"

--- a/schema/handle_msg.json
+++ b/schema/handle_msg.json
@@ -796,6 +796,12 @@
             "permit_name"
           ],
           "properties": {
+            "padding": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "permit_name": {
               "type": "string"
             }

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -195,7 +195,7 @@
           ],
           "properties": {
             "permit": {
-              "$ref": "#/definitions/Permit"
+              "$ref": "#/definitions/Permit_for_TokenPermissions"
             },
             "query": {
               "$ref": "#/definitions/QueryWithPermit"
@@ -213,31 +213,7 @@
     "HumanAddr": {
       "type": "string"
     },
-    "Permission": {
-      "type": "string",
-      "enum": [
-        "allowance",
-        "balance",
-        "history",
-        "owner"
-      ]
-    },
-    "Permit": {
-      "type": "object",
-      "required": [
-        "params",
-        "signature"
-      ],
-      "properties": {
-        "params": {
-          "$ref": "#/definitions/PermitParams"
-        },
-        "signature": {
-          "$ref": "#/definitions/PermitSignature"
-        }
-      }
-    },
-    "PermitParams": {
+    "PermitParams_for_TokenPermissions": {
       "type": "object",
       "required": [
         "allowed_tokens",
@@ -258,7 +234,7 @@
         "permissions": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Permission"
+            "$ref": "#/definitions/TokenPermissions"
           }
         },
         "permit_name": {
@@ -278,6 +254,21 @@
         },
         "signature": {
           "$ref": "#/definitions/Binary"
+        }
+      }
+    },
+    "Permit_for_TokenPermissions": {
+      "type": "object",
+      "required": [
+        "params",
+        "signature"
+      ],
+      "properties": {
+        "params": {
+          "$ref": "#/definitions/PermitParams_for_TokenPermissions"
+        },
+        "signature": {
+          "$ref": "#/definitions/PermitSignature"
         }
       }
     },
@@ -396,6 +387,15 @@
             }
           }
         }
+      ]
+    },
+    "TokenPermissions": {
+      "type": "string",
+      "enum": [
+        "allowance",
+        "balance",
+        "history",
+        "owner"
       ]
     }
   }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Binary, HumanAddr, Uint128};
 
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct TransferAction {
     pub recipient: HumanAddr,
@@ -13,7 +13,7 @@ pub struct TransferAction {
     pub memo: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct SendAction {
     pub recipient: HumanAddr,
@@ -23,7 +23,7 @@ pub struct SendAction {
     pub memo: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct TransferFromAction {
     pub owner: HumanAddr,
@@ -32,7 +32,7 @@ pub struct TransferFromAction {
     pub memo: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct SendFromAction {
     pub owner: HumanAddr,
@@ -43,7 +43,7 @@ pub struct SendFromAction {
     pub memo: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct MintAction {
     pub recipient: HumanAddr,
@@ -51,7 +51,7 @@ pub struct MintAction {
     pub memo: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct BurnFromAction {
     pub owner: HumanAddr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod transaction_history;
 mod utils;
 mod viewing_key;
 
+#[cfg(not(feature = "library"))]
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use super::contract;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
-mod batch;
+pub mod batch;
 pub mod contract;
 pub mod msg;
 mod rand;
 pub mod receiver;
 pub mod state;
-mod transaction_history;
+pub mod transaction_history;
 mod utils;
-mod viewing_key;
+pub mod viewing_key;
 
 #[cfg(not(feature = "library"))]
 #[cfg(target_arch = "wasm32")]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -9,13 +9,13 @@ use crate::viewing_key::ViewingKey;
 use cosmwasm_std::{Binary, HumanAddr, StdError, StdResult, Uint128};
 use secret_toolkit::permit::Permit;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 pub struct InitialBalance {
     pub address: HumanAddr,
     pub amount: Uint128,
 }
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 pub struct InitMsg {
     pub name: String,
     pub admin: Option<HumanAddr>,
@@ -35,7 +35,7 @@ impl InitMsg {
 /// This type represents optional configuration values which can be overridden.
 /// All values are optional and have defaults which are more private by default,
 /// but can be overridden if necessary
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Default, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, Defualt, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct InitConfig {
     /// Indicates whether the total supply is public or should be kept secret.
@@ -77,7 +77,7 @@ impl InitConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum HandleMsg {
     // Native coin interactions
@@ -220,7 +220,7 @@ pub enum HandleMsg {
     },
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum HandleAnswer {
     // Native
@@ -318,7 +318,7 @@ pub enum HandleAnswer {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     TokenInfo {},
@@ -372,7 +372,7 @@ impl QueryMsg {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryWithPermit {
     Allowance {
@@ -390,7 +390,7 @@ pub enum QueryWithPermit {
     },
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryAnswer {
     TokenInfo {
@@ -438,19 +438,19 @@ pub enum QueryAnswer {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 pub struct CreateViewingKeyResponse {
     pub key: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ResponseStatus {
     Success,
     Failure,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ContractStatusLevel {
     NormalRun,

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -35,7 +35,7 @@ impl InitMsg {
 /// This type represents optional configuration values which can be overridden.
 /// All values are optional and have defaults which are more private by default,
 /// but can be overridden if necessary
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, Defualt, PartialEq)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, Default, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct InitConfig {
     /// Indicates whether the total supply is public or should be kept secret.

--- a/src/transaction_history.rs
+++ b/src/transaction_history.rs
@@ -17,7 +17,7 @@ const PREFIX_TRANSFERS: &[u8] = b"transfers";
 // Since it's 64 bits long, even at 50 tx/s it would take
 // over 11 billion years for it to rollback. I'm pretty sure
 // we'll have bigger issues by then.
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 pub struct Tx {
     pub id: u64,
     pub from: HumanAddr,

--- a/src/viewing_key.rs
+++ b/src/viewing_key.rs
@@ -11,7 +11,7 @@ use crate::utils::{create_hashed_password, ct_slice_compare};
 pub const VIEWING_KEY_SIZE: usize = 32;
 pub const VIEWING_KEY_PREFIX: &str = "api_key_";
 
-#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 pub struct ViewingKey(pub String);
 
 impl ViewingKey {


### PR DESCRIPTION
This PR aims to allow extensions of the reference implementation. It follows a pattern adopted a good while ago in [cw-plus](https://github.com/CosmWasm/cw-plus/blob/main/contracts/cw20-base/src/contract.rs#L89).

The core change is an introduction of the `library` feature, which, when selected, omits the WASM bindings.

Thanks to that it's possible to build an extended version of the reference implementation, for example:

- [adding marketing info](https://github.com/atomiklabs/scrt-plus/blob/use-snip-20/contracts/snipix/src/contract.rs) to the SNIP-20 token contract

---
 
Feel free to share feedback, and hopefully, accept the PR.

