### PR TITLE
Add allowances_given and allowances_received query functions

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5042,13 +5042,13 @@ mod tests {
             owner: "owner1".to_string(),
             key: vk.clone(),
             page: Some(2),
-            page_size: 7,
+            page_size: 8,
         };
         let query_result = query(deps.as_ref(), mock_env(), query_msg);
         match from_binary(&query_result.unwrap()).unwrap() {
             QueryAnswer::AllowancesGiven { owner, allowances, count } => {
                 assert_eq!(owner, "owner1".to_string());
-                assert_eq!(allowances.len(), 2);
+                assert_eq!(allowances.len(), 4);
                 assert_eq!(count, num_spenders);
             },
             _ => panic!("Unexpected"),

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -11,10 +11,10 @@ use secret_toolkit::viewing_key::{ViewingKey, ViewingKeyStore};
 use secret_toolkit_crypto::{sha_256, Prng, SHA256_HASH_SIZE};
 
 use crate::batch;
-use crate::msg::QueryWithPermit;
 use crate::msg::{
     ContractStatusLevel, Decoyable, ExecuteAnswer, ExecuteMsg, InstantiateMsg, QueryAnswer,
-    QueryMsg, ResponseStatus::Success,
+    QueryMsg, ResponseStatus::Success, QueryWithPermit, AllowanceGivenResult, 
+    AllowanceReceivedResult,
 };
 use crate::receiver::Snip20ReceiveMsg;
 use crate::state::{
@@ -474,6 +474,24 @@ fn permit_queries(deps: Deps, permit: Permit, query: QueryWithPermit) -> Result<
 
             query_allowance(deps, owner, spender)
         }
+        QueryWithPermit::AllowancesGiven { owner, page, page_size } => {
+            if !permit.check_permission(&TokenPermissions::Allowance) {
+                return Err(StdError::generic_err(format!(
+                    "No permission to query all allowances, got permissions {:?}",
+                    permit.params.permissions
+                )));
+            }
+            query_allowances_given(deps, owner, page.unwrap_or(0), page_size)
+        }
+        QueryWithPermit::AllowancesReceived { spender, page, page_size } => {
+            if !permit.check_permission(&TokenPermissions::Allowance) {
+                return Err(StdError::generic_err(format!(
+                    "No permission to query all allowed, got permissions {:?}",
+                    permit.params.permissions
+                )));
+            }
+            query_allowances_received(deps, spender, page.unwrap_or(0), page_size)  
+        }
     }
 }
 
@@ -513,6 +531,18 @@ pub fn viewing_keys_queries(deps: Deps, msg: QueryMsg) -> StdResult<Binary> {
                     should_filter_decoys,
                 ),
                 QueryMsg::Allowance { owner, spender, .. } => query_allowance(deps, owner, spender),
+                QueryMsg::AllowancesGiven { 
+                    owner, 
+                    page, 
+                    page_size, 
+                    .. 
+                } => query_allowances_given(deps, owner, page.unwrap_or(0), page_size),
+                QueryMsg::AllowancesReceived { 
+                    spender, 
+                    page, 
+                    page_size, 
+                    .. 
+                } => query_allowances_received(deps, spender, page.unwrap_or(0), page_size),
                 _ => panic!("This query type does not require authentication"),
             };
         }
@@ -900,7 +930,7 @@ fn set_contract_status(
 }
 
 pub fn query_allowance(deps: Deps, owner: String, spender: String) -> StdResult<Binary> {
-    // Notice that if query_allowance() was called by a viewking-key call, the addresses of 'owner'
+    // Notice that if query_allowance() was called by a viewing-key call, the addresses of 'owner'
     // and 'spender' have already been validated.
     // The addresses of 'owner' and 'spender' should not be validated if query_allowance() was
     // called by a permit call, for compatibility with non-Secret addresses.
@@ -914,6 +944,56 @@ pub fn query_allowance(deps: Deps, owner: String, spender: String) -> StdResult<
         spender,
         allowance: Uint128::new(allowance.amount),
         expiration: allowance.expiration,
+    };
+    to_binary(&response)
+}
+
+pub fn query_allowances_given(deps: Deps, owner: String, page: u32, page_size: u32) -> StdResult<Binary> {
+    // Notice that if query_all_allowances_given() was called by a viewing-key call, 
+    // the address of 'owner' has already been validated.
+    // The addresses of 'owner' should not be validated if query_all_allowances_given() was
+    // called by a permit call, for compatibility with non-Secret addresses.
+    let owner = Addr::unchecked(owner);
+
+    let all_allowances = AllowancesStore::all_allowances(deps.storage, &owner, page, page_size).unwrap_or(vec![]);
+
+    let allowances_result = all_allowances.into_iter().map(|(spender, allowance)| {
+        AllowanceGivenResult {
+            spender,
+            allowance: Uint128::from(allowance.amount),
+            expiration: allowance.expiration,
+        }
+    }).collect();
+
+    let response = QueryAnswer::AllowancesGiven { 
+        owner: owner.clone(),
+        allowances: allowances_result, 
+        count: AllowancesStore::num_allowances(deps.storage, &owner), 
+    };
+    to_binary(&response)
+}
+
+pub fn query_allowances_received(deps: Deps, spender: String, page: u32, page_size: u32) -> StdResult<Binary> {
+    // Notice that if query_all_allowances_received() was called by a viewing-key call, 
+    // the address of 'spender' has already been validated.
+    // The addresses of 'spender' should not be validated if query_all_allowances_received() was
+    // called by a permit call, for compatibility with non-Secret addresses.
+    let spender = Addr::unchecked(spender);
+
+    let all_allowed = AllowancesStore::all_allowed(deps.storage, &spender, page, page_size).unwrap_or(vec![]);
+
+    let allowances = all_allowed.into_iter().map(|(owner, allowance)| {
+        AllowanceReceivedResult {
+            owner,
+            allowance: Uint128::from(allowance.amount),
+            expiration: allowance.expiration,
+        }
+    }).collect();
+
+    let response = QueryAnswer::AllowancesReceived { 
+        spender: spender.clone(),
+        allowances, 
+        count: AllowancesStore::num_allowed(deps.storage, &spender), 
     };
     to_binary(&response)
 }
@@ -4828,6 +4908,207 @@ mod tests {
         };
         assert_eq!(allowance, Uint128::new(0));
     }
+
+    #[test]
+    fn test_query_all_allowances() {
+        let num_owners = 3;
+        let num_spenders = 20;
+        let vk = "key".to_string();
+
+        let initial_balances: Vec<InitialBalance> = (0..num_owners).into_iter().map(|i| {
+            InitialBalance {
+                address: format!("owner{}", i),
+                amount: Uint128::new(5000),
+            }
+        }).collect();
+        let (init_result, mut deps) = init_helper(initial_balances);
+        assert!(
+            init_result.is_ok(),
+            "Init failed: {}",
+            init_result.err().unwrap()
+        );
+        for i in 0..num_owners {
+            let handle_msg = ExecuteMsg::SetViewingKey {
+                key: vk.clone(),
+                padding: None,
+            };
+            let info = mock_info(format!("owner{}", i).as_str(), &[]);
+
+            let handle_result = execute(deps.as_mut(), mock_env(), info, handle_msg);
+
+            let unwrapped_result: ExecuteAnswer =
+                from_binary(&handle_result.unwrap().data.unwrap()).unwrap();
+            assert_eq!(
+                to_binary(&unwrapped_result).unwrap(),
+                to_binary(&ExecuteAnswer::SetViewingKey {
+                    status: ResponseStatus::Success
+                })
+                .unwrap(),
+            );
+        }
+
+        for i in 0..num_owners {
+            for j in 0..num_spenders {
+                let handle_msg = ExecuteMsg::IncreaseAllowance {
+                    spender: format!("spender{}", j),
+                    amount: Uint128::new(50),
+                    padding: None,
+                    expiration: None,
+                };
+                let info = mock_info(format!("owner{}", i).as_str(), &[]);
+
+                let handle_result = execute(deps.as_mut(), mock_env(), info, handle_msg);
+                assert!(
+                    handle_result.is_ok(),
+                    "handle() failed: {}",
+                    handle_result.err().unwrap()
+                );
+
+                let handle_msg = ExecuteMsg::SetViewingKey {
+                    key: vk.clone(),
+                    padding: None,
+                };
+                let info = mock_info(format!("spender{}", j).as_str(), &[]);
+
+                let handle_result = execute(deps.as_mut(), mock_env(), info, handle_msg);
+
+                let unwrapped_result: ExecuteAnswer =
+                    from_binary(&handle_result.unwrap().data.unwrap()).unwrap();
+                assert_eq!(
+                    to_binary(&unwrapped_result).unwrap(),
+                    to_binary(&ExecuteAnswer::SetViewingKey {
+                        status: ResponseStatus::Success
+                    })
+                    .unwrap(),
+                );
+            }
+        }
+
+        let query_msg = QueryMsg::AllowancesGiven {
+            owner: "owner0".to_string(),
+            key: vk.clone(),
+            page: None,
+            page_size: 5,
+        };
+        let query_result = query(deps.as_ref(), mock_env(), query_msg);
+        match from_binary(&query_result.unwrap()).unwrap() {
+            QueryAnswer::AllowancesGiven { owner, allowances, count } => {
+                assert_eq!(owner, "owner0".to_string());
+                assert_eq!(allowances.len(), 5);
+                assert_eq!(allowances[0].spender, "spender0");
+                assert_eq!(allowances[0].allowance, Uint128::from(50_u128));
+                assert_eq!(allowances[0].expiration, None);
+                assert_eq!(count, num_spenders);
+            },
+            _ => panic!("Unexpected"),
+        };
+
+        let query_msg = QueryMsg::AllowancesGiven {
+            owner: "owner1".to_string(),
+            key: vk.clone(),
+            page: Some(1),
+            page_size: 5,
+        };
+        let query_result = query(deps.as_ref(), mock_env(), query_msg);
+        match from_binary(&query_result.unwrap()).unwrap() {
+            QueryAnswer::AllowancesGiven { owner, allowances, count } => {
+                assert_eq!(owner, "owner1".to_string());
+                assert_eq!(allowances.len(), 5);
+                assert_eq!(allowances[0].spender, "spender5");
+                assert_eq!(allowances[0].allowance, Uint128::from(50_u128));
+                assert_eq!(allowances[0].expiration, None);
+                assert_eq!(count, num_spenders);
+            },
+            _ => panic!("Unexpected"),
+        };
+
+        let query_msg = QueryMsg::AllowancesGiven {
+            owner: "owner1".to_string(),
+            key: vk.clone(),
+            page: Some(0),
+            page_size: 23,
+        };
+        let query_result = query(deps.as_ref(), mock_env(), query_msg);
+        match from_binary(&query_result.unwrap()).unwrap() {
+            QueryAnswer::AllowancesGiven { owner, allowances, count } => {
+                assert_eq!(owner, "owner1".to_string());
+                assert_eq!(allowances.len(), 20);
+                assert_eq!(count, num_spenders);
+            },
+            _ => panic!("Unexpected"),
+        };
+
+        let query_msg = QueryMsg::AllowancesGiven {
+            owner: "owner1".to_string(),
+            key: vk.clone(),
+            page: Some(2),
+            page_size: 7,
+        };
+        let query_result = query(deps.as_ref(), mock_env(), query_msg);
+        match from_binary(&query_result.unwrap()).unwrap() {
+            QueryAnswer::AllowancesGiven { owner, allowances, count } => {
+                assert_eq!(owner, "owner1".to_string());
+                assert_eq!(allowances.len(), 2);
+                assert_eq!(count, num_spenders);
+            },
+            _ => panic!("Unexpected"),
+        };
+
+        let query_msg = QueryMsg::AllowancesGiven {
+            owner: "owner2".to_string(),
+            key: vk.clone(),
+            page: Some(5),
+            page_size: 5,
+        };
+        let query_result = query(deps.as_ref(), mock_env(), query_msg);
+        match from_binary(&query_result.unwrap()).unwrap() {
+            QueryAnswer::AllowancesGiven { owner, allowances, count } => {
+                assert_eq!(owner, "owner2".to_string());
+                assert_eq!(allowances.len(), 0);
+                assert_eq!(count, num_spenders);
+            },
+            _ => panic!("Unexpected"),
+        };
+
+        let query_msg = QueryMsg::AllowancesReceived {
+            spender: "spender0".to_string(),
+            key: vk.clone(),
+            page: None,
+            page_size: 10,
+        };
+        let query_result = query(deps.as_ref(), mock_env(), query_msg);
+        match from_binary(&query_result.unwrap()).unwrap() {
+            QueryAnswer::AllowancesReceived { spender, allowances, count } => {
+                assert_eq!(spender, "spender0".to_string());
+                assert_eq!(allowances.len(), 3);
+                assert_eq!(allowances[0].owner, "owner0");
+                assert_eq!(allowances[0].allowance, Uint128::from(50_u128));
+                assert_eq!(allowances[0].expiration, None);
+                assert_eq!(count, num_owners);
+            },
+            _ => panic!("Unexpected"),
+        };
+
+        let query_msg = QueryMsg::AllowancesReceived {
+            spender: "spender1".to_string(),
+            key: vk.clone(),
+            page: Some(1),
+            page_size: 1,
+        };
+        let query_result = query(deps.as_ref(), mock_env(), query_msg);
+        match from_binary(&query_result.unwrap()).unwrap() {
+            QueryAnswer::AllowancesReceived { spender, allowances, count } => {
+                assert_eq!(spender, "spender1".to_string());
+                assert_eq!(allowances.len(), 1);
+                assert_eq!(allowances[0].owner, "owner1");
+                assert_eq!(allowances[0].allowance, Uint128::from(50_u128));
+                assert_eq!(allowances[0].expiration, None);
+                assert_eq!(count, num_owners);
+            },
+            _ => panic!("Unexpected"),
+        };
+    }
+
 
     #[test]
     fn test_query_balance() {

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -446,6 +446,18 @@ pub enum QueryMsg {
         spender: String,
         key: String,
     },
+    AllowancesGiven {
+        owner: String,
+        key: String,
+        page: Option<u32>,
+        page_size: u32,
+    },
+    AllowancesReceived {
+        spender: String,
+        key: String,
+        page: Option<u32>,
+        page_size: u32,
+    },
     Balance {
         address: String,
         key: String,
@@ -497,6 +509,14 @@ impl QueryMsg {
 
                 Ok((vec![owner, spender], key.clone()))
             }
+            Self::AllowancesGiven { owner, key, .. } => {
+                let owner = api.addr_validate(owner.as_str())?;
+                Ok((vec![owner], key.clone()))
+            }
+            Self::AllowancesReceived { spender, key, .. } => {
+                let spender = api.addr_validate(spender.as_str())?;
+                Ok((vec![spender], key.clone()))
+            }
             _ => panic!("This query type does not require authentication"),
         }
     }
@@ -509,6 +529,16 @@ pub enum QueryWithPermit {
     Allowance {
         owner: String,
         spender: String,
+    },
+    AllowancesGiven { 
+        owner: String, 
+        page: Option<u32>, 
+        page_size: u32 
+    },
+    AllowancesReceived { 
+        spender: String, 
+        page: Option<u32>, 
+        page_size: u32 
     },
     Balance {},
     TransferHistory {
@@ -553,6 +583,16 @@ pub enum QueryAnswer {
         allowance: Uint128,
         expiration: Option<u64>,
     },
+    AllowancesGiven {
+        owner: Addr,
+        allowances: Vec<AllowanceGivenResult>,
+        count: u32,
+    },
+    AllowancesReceived {
+        spender: Addr,
+        allowances: Vec<AllowanceReceivedResult>,
+        count: u32,
+    },
     Balance {
         amount: Uint128,
     },
@@ -571,6 +611,21 @@ pub enum QueryAnswer {
         minters: Vec<Addr>,
     },
 }
+
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+pub struct AllowanceGivenResult {
+    pub spender: Addr,
+    pub allowance: Uint128,
+    pub expiration: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]
+pub struct AllowanceReceivedResult {
+    pub owner: Addr,
+    pub allowance: Uint128,
+    pub expiration: Option<u64>,
+}
+
 
 #[derive(Serialize, Deserialize, Clone, JsonSchema, Debug)]
 #[cfg_attr(test, derive(Eq, PartialEq))]

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, StdError, StdResult, Storage};
 use secret_toolkit::serialization::Json;
-use secret_toolkit::storage::{Item, Keymap};
+use secret_toolkit::storage::{Item, Keymap, Keyset};
 use secret_toolkit_crypto::SHA256_HASH_SIZE;
 
 use crate::msg::ContractStatusLevel;
@@ -18,6 +18,7 @@ pub const KEY_TX_COUNT: &[u8] = b"tx-count";
 pub const PREFIX_CONFIG: &[u8] = b"config";
 pub const PREFIX_BALANCES: &[u8] = b"balances";
 pub const PREFIX_ALLOWANCES: &[u8] = b"allowances";
+pub const PREFIX_ALLOWED: &[u8] = b"allowed";
 pub const PREFIX_VIEW_KEY: &[u8] = b"viewingkey";
 pub const PREFIX_RECEIVERS: &[u8] = b"receivers";
 
@@ -227,12 +228,13 @@ impl Allowance {
     }
 }
 
-pub static ALLOWANCES: Keymap<(Addr, Addr), Allowance> = Keymap::new(PREFIX_ALLOWANCES);
+pub static ALLOWANCES: Keymap<Addr, Allowance> = Keymap::new(PREFIX_ALLOWANCES);
+pub static ALLOWED: Keyset<Addr> = Keyset::new(PREFIX_ALLOWED);
 pub struct AllowancesStore {}
 impl AllowancesStore {
     pub fn load(store: &dyn Storage, owner: &Addr, spender: &Addr) -> Allowance {
-        ALLOWANCES
-            .get(store, &(owner.clone(), spender.clone()))
+        ALLOWANCES.add_suffix(owner.as_bytes())
+            .get(store, &spender.clone())
             .unwrap_or_default()
     }
 
@@ -242,8 +244,37 @@ impl AllowancesStore {
         spender: &Addr,
         allowance: &Allowance,
     ) -> StdResult<()> {
-        ALLOWANCES.insert(store, &(owner.clone(), spender.clone()), allowance)
+        ALLOWED.add_suffix(spender.as_bytes()).insert(store, owner)?;
+        ALLOWANCES.add_suffix(owner.as_bytes()).insert(store, spender, allowance)
     }
+
+    pub fn all_allowances(store: &dyn Storage, owner: &Addr, page: u32, page_size: u32) -> StdResult<Vec<(Addr, Allowance)>> {
+        ALLOWANCES.add_suffix(owner.as_bytes())
+            .paging(store, page, page_size)
+    }
+
+    pub fn num_allowances(store: &dyn Storage, owner: &Addr) -> u32 {
+        ALLOWANCES.add_suffix(owner.as_bytes()).get_len(store).unwrap_or(0)
+    }
+
+    pub fn all_allowed(store: &dyn Storage, spender: &Addr, page: u32, page_size: u32) -> StdResult<Vec<(Addr, Allowance)>> {
+        let owners = ALLOWED.add_suffix(spender.as_bytes())
+            .paging(store, page, page_size)?;
+        let owners_allowances = owners
+            .into_iter()
+            .map(|owner| (owner.clone(), AllowancesStore::load(store, &owner, spender)))
+            .collect();
+        Ok(owners_allowances)
+    }
+
+    pub fn num_allowed(store: &dyn Storage, spender: &Addr) -> u32 {
+        ALLOWED.add_suffix(spender.as_bytes()).get_len(store).unwrap_or(0)
+    }
+
+    pub fn is_allowed(store: &dyn Storage, owner: &Addr, spender: &Addr) -> bool {
+        ALLOWED.add_suffix(spender.as_bytes()).contains(store, owner)
+    }
+
 }
 
 // Receiver Interface


### PR DESCRIPTION
This PR updates allowances storage and adds two new queries: `allowances_given`, `allowances_received`. 

More detailed information found in this issue: https://github.com/scrtlabs/snip20-reference-impl/issues/58
Related discussion: https://github.com/SecretFoundation/SNIPs/pull/13#issuecomment-848655804