### PR TITLE
add note about tagged releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # SNIP-20 Reference Implementation
 
 This is an implementation of a [SNIP-20](https://docs.scrt.network/secret-network-documentation/development/snips/snip-20-spec-private-fungible-tokens), [SNIP-21](https://docs.scrt.network/secret-network-documentation/development/snips/snip-21-minor-improvements-to-snip-20), [SNIP-22](https://docs.scrt.network/secret-network-documentation/development/snips/snip-22-batch-operations-for-snip-20-contracts), [SNIP-23](https://docs.scrt.network/secret-network-documentation/development/snips/snip-23-improved-ux-to-snip-20-send-operations) and [SNIP-24](https://docs.scrt.network/secret-network-documentation/development/snips/snip-24-query-permits-for-snip-20-tokens) compliant token contract.
+
+> **Note:**
+> The master branch contains new features not covered by officially-released SNIPs and may be subject to change. When releasing a token on mainnet, we recommend you start with a [tagged release](https://github.com/scrtlabs/snip20-reference-impl/tags) to ensure compatibility with SNIP standards.
+
 At the time of token creation you may configure:
 * Public Total Supply:  If you enable this, the token's total supply will be displayed whenever a TokenInfo query is performed.  DEFAULT: false
 * Enable Deposit: If you enable this, you will be able to convert from SCRT to the token.*  DEFAULT: false


### PR DESCRIPTION
This PR simply adds a note the README to recommend that mainnet tokens be based on tagged releases, rather than the latest version of the master branch. This way we make sure code is not considered official until the associated SNIP has been added and approved on the [SNIPs repo](https://github.com/SecretFoundation/SNIPs).