### PR TITLE
Update SNIP links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SNIP-20 Reference Implementation
 
-This is an implementation of a [SNIP-20](https://docs.scrt.network/secret-network-documentation/development/snips/snip-20-spec-private-fungible-tokens), [SNIP-21](https://docs.scrt.network/secret-network-documentation/development/snips/snip-21-minor-improvements-to-snip-20), [SNIP-22](https://docs.scrt.network/secret-network-documentation/development/snips/snip-22-batch-operations-for-snip-20-contracts), [SNIP-23](https://docs.scrt.network/secret-network-documentation/development/snips/snip-23-improved-ux-to-snip-20-send-operations) and [SNIP-24](https://docs.scrt.network/secret-network-documentation/development/snips/snip-24-query-permits-for-snip-20-tokens) compliant token contract.
+This is an implementation of a [SNIP-20](https://github.com/SecretFoundation/SNIPs/blob/master/SNIP-20.md), [SNIP-21](https://github.com/SecretFoundation/SNIPs/blob/master/SNIP-21.md), [SNIP-22](https://github.com/SecretFoundation/SNIPs/blob/master/SNIP-22.md), [SNIP-23](https://github.com/SecretFoundation/SNIPs/blob/master/SNIP-23.md) and [SNIP-24](https://github.com/SecretFoundation/SNIPs/blob/master/SNIP-24.md) compliant token contract.
 
 > **Note:**
 > The master branch contains new features not covered by officially-released SNIPs and may be subject to change. When releasing a token on mainnet, we recommend you start with a [tagged release](https://github.com/scrtlabs/snip20-reference-impl/tags) to ensure compatibility with SNIP standards.


### PR DESCRIPTION
Updated links to point back to SNIP's public GitHub repo